### PR TITLE
Changes to non-capitalized name

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,7 @@
   "name" : "FanFou",
   "perl" : "6.c",
   "provides" : {
-    "FanFou" : "lib/FanFou.pm6"
+    "FanFou" : "lib/fanfou.pm6"
   },
   "resources" : [ ],
   "source-url" : "https://github.com/ohmycloud/fanfou-p6.git",


### PR DESCRIPTION
This was provoking an error in Travis. Maybe you should bump up
version to avoid that. It is not going to install correctly, I think,
with this error.